### PR TITLE
Enable systemd security mechanisms in our unit files

### DIFF
--- a/src/scripts/debian/cloudgateway.service.tmpl
+++ b/src/scripts/debian/cloudgateway.service.tmpl
@@ -9,5 +9,14 @@ User=cloudgw
 ExecStart=@CMAKE_INSTALL_PREFIX@//bin/CloudGatewayStorageManager start
 ExecReload=/bin/kill -HUP $MAINPID
 
+ProtectSystem=full
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+CapabilityBoundingSet=
+NoNewPrivileges=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+LimitNOFILE=163840
+
 [Install]
 WantedBy=multi-user.target

--- a/src/scripts/debian/cloudgatewaymount@.service.tmpl
+++ b/src/scripts/debian/cloudgatewaymount@.service.tmpl
@@ -8,5 +8,14 @@ Requires=cloudgateway.service
 User=cloudgw
 ExecStart=@CMAKE_INSTALL_PREFIX@/bin/CloudGatewayMount %i @CMAKE_INSTALL_PREFIX@//etc/CloudGatewayConfiguration.xml
 
+ProtectSystem=full
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+CapabilityBoundingSet=
+NoNewPrivileges=true
+RestrictAddressFamilies=AF_UNIX
+LimitNOFILE=163840
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
We should double check that it doesn't cause any issue, especially with regard to file system accesses. The communication socket is in `/run`, as is the pid file, but I may have missed some other files we need access to.