### PR TITLE
Change default path for CommunicationSocket, PidFile, LogFile & StatsJSONFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,17 @@ sudo useradd -g cloudgw -m --home-dir /home/cloudgw cloudgw
 sudo chgrp cloudgw /usr/local/etc/CloudGatewayConfiguration.xml
 sudo chmod g+rw /usr/local/etc/CloudGatewayConfiguration.xml
 
-sudo mkdir -p /usr/local/run/cloudgateway
-sudo chgrp cloudgw /usr/local/run/cloudgateway
-sudo chmod g+w /usr/local/run/cloudgateway
+```
+
+If you are not using the systemd unit files:
+```
+sudo mkdir -p /run/cloudgateway
+sudo chown cloudgw:cloudgw /run/cloudgateway
+sudo chmod 0750 /run/cloudgateway
+
+sudo mkdir -p /var/log/cloudgateway
+sudo chown cloudgw:cloudgw /var/log/cloudgateway
+sudo chmod 0750 /var/log/cloudgateway
 ```
 
 Configuration
@@ -122,6 +130,8 @@ Run CloudGateway with systemd
 sudo cp /usr/local/share/cloudgateway/resources/cloudgatewaymount\@.service /etc/systemd/system
 sudo cp /usr/local/share/cloudgateway/resources/cloudgateway.service /etc/systemd/system
 ```
+
+LogsDirectory, LogsDirectoryMode, RuntimeDirectoryPreserve requires systemd 235 (for Debian users, it is available in the stretch-backports repository).
 
 2. Reload systemd
 ```

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ sudo cp /usr/local/share/cloudgateway/resources/cloudgatewaymount\@.service /etc
 sudo cp /usr/local/share/cloudgateway/resources/cloudgateway.service /etc/systemd/system
 ```
 
-LogsDirectory, LogsDirectoryMode, RuntimeDirectoryPreserve requires systemd 235 (for Debian users, it is available in the stretch-backports repository).
+LogsDirectory, LogsDirectoryMode, RuntimeDirectoryPreserve require systemd 235 (for Debian users, it is available in the stretch-backports repository).
 
 2. Reload systemd
 ```

--- a/docs/configuration_options.rst
+++ b/docs/configuration_options.rst
@@ -73,7 +73,7 @@ Configuration/General/LogFile
 
 -  Required: false
 
--  *Example: /tmp/CloudGatewayStorageManager.err*
+-  *Example: /var/log/cloudgateway/CloudGatewayStorageManager.err*
 
 Path to the file where the Cloud Gateway Storage Manager process will
 write its log messages when needed. Creation and write access to this
@@ -97,9 +97,9 @@ Configuration/General/StatsJSONFile
 
 -  Required: false
 
--  Default: /tmp/cgStats.json
+-  Default: /run/cloudgateway/cgStats.json
 
--  *Example: /tmp/cgStats.json*
+-  *Example: /run/cloudgateway/cgStats.json*
 
 Path to the JSON file that the Stats process will write statistics
 informations to.

--- a/src/scripts/debian/cloudgateway.service.tmpl
+++ b/src/scripts/debian/cloudgateway.service.tmpl
@@ -3,11 +3,17 @@ Description=Cloud Gateway
 After=network.target
 
 [Service]
-PIDFile=@CMAKE_INSTALL_PREFIX@/run/cloudgateway/CloudGatewayStorageManager.pid
+PIDFile=/run/cloudgateway/CloudGatewayStorageManager.pid
 Type=forking
 User=cloudgw
 ExecStart=@CMAKE_INSTALL_PREFIX@//bin/CloudGatewayStorageManager start
 ExecReload=/bin/kill -HUP $MAINPID
+
+LogsDirectory=cloudgateway
+LogsDirectoryMode=0750
+RuntimeDirectory=cloudgateway
+RuntimeDirectoryMode=0750
+RuntimeDirectoryPreserve=restart
 
 [Install]
 WantedBy=multi-user.target

--- a/src/scripts/debian/cloudgatewaymount@.service.tmpl
+++ b/src/scripts/debian/cloudgatewaymount@.service.tmpl
@@ -9,5 +9,11 @@ User=cloudgw
 ExecStart=@CMAKE_INSTALL_PREFIX@/bin/CloudGatewayMount %i @CMAKE_INSTALL_PREFIX@//etc/CloudGatewayConfiguration.xml
 ExecStop=@CMAKE_INSTALL_PREFIX@/bin/CloudGatewayUnmount @CMAKE_INSTALL_PREFIX@//etc/CloudGatewayConfiguration.xml %i
 
+LogsDirectory=cloudgateway
+LogsDirectoryMode=0750
+RuntimeDirectory=cloudgateway
+RuntimeDirectoryMode=0750
+RuntimeDirectoryPreserve=restart
+
 [Install]
 WantedBy=multi-user.target

--- a/src/tests/CloudGatewayConfiguration.xml.tmpl
+++ b/src/tests/CloudGatewayConfiguration.xml.tmpl
@@ -6,12 +6,12 @@
     <FiltersPath>@CMAKE_INSTALL_PREFIX@/lib/</FiltersPath>
     <DBBackendsPath>@CMAKE_INSTALL_PREFIX@/lib/</DBBackendsPath>
     <ResourcesPath>@CMAKE_INSTALL_PREFIX@/share/cloudgateway/resources/</ResourcesPath>
-    <CommunicationSocket>@CMAKE_INSTALL_PREFIX@/run/cloudgateway/CloudGatewayStorageManager.sock</CommunicationSocket>
-    <PidFile>@CMAKE_INSTALL_PREFIX@/run/cloudgateway/CloudGatewayStorageManager.pid</PidFile>
-    <LogFile>/tmp/CloudGatewayStorageManager.err</LogFile>
+    <CommunicationSocket>/run/cloudgateway/CloudGatewayStorageManager.sock</CommunicationSocket>
+    <PidFile>/run/cloudgateway/CloudGatewayStorageManager.pid</PidFile>
+    <LogFile>/var/log/cloudgateway/CloudGatewayStorageManager.err</LogFile>
+    <StatsJSONFile>/run/cloudgateway/cgStatsFile.json</StatsJSONFile>
     <MonitorInformationsPath>/cgStorageManagerMonitor.shared</MonitorInformationsPath>
     <Daemonize>true</Daemonize>
-    <StatsJSONFile>/tmp/cgStatsFile.json</StatsJSONFile>
   </General>
 
   <Monitor>

--- a/src/tests/fonctionnal.sh
+++ b/src/tests/fonctionnal.sh
@@ -26,7 +26,7 @@ function fail()
 {
     echo "Failed: $1";
     fusermount -u ${MOUNT_POINT}
-    kill -USR1 `cat /tmp/CloudGatewayStorageManager.pid`
+    kill -USR1 `cat /run/cloudgateway/CloudGatewayStorageManager.pid`
     exit 1;
 }
 
@@ -548,7 +548,7 @@ fi
 
 sleep 10
 
-kill -USR1 `cat /tmp/CloudGatewayStorageManager.pid`
+kill -USR1 `cat /run/cloudgateway/CloudGatewayStorageManager.pid`
 
 if [ $? -ne 0 ]; then
     fail "cgStorageManager stop failure.";

--- a/src/tests/fonctionnal_failed_instances.sh
+++ b/src/tests/fonctionnal_failed_instances.sh
@@ -33,7 +33,7 @@ function fail()
 {
     echo "Failed: $1";
     fusermount -u ${MOUNT_POINT}
-    kill -USR1 `cat /tmp/CloudGatewayStorageManager.pid`
+    kill -USR1 `cat /run/cloudgateway/CloudGatewayStorageManager.pid`
     exit 1;
 }
 
@@ -143,7 +143,7 @@ fusermount -u /mnt/fuse
 
 rm -f "${CG_STORAGE_MANAGER_SYMLINK_CONF}"
 ln -s "${CG_STORAGE_MANAGER_FIRST_DOWN_CONF}" "${CG_STORAGE_MANAGER_SYMLINK_CONF}"
-kill -HUP `cat /tmp/CloudGatewayStorageManager.pid`
+kill -HUP `cat /run/cloudgateway/CloudGatewayStorageManager.pid`
 
 # Ok, now we try to access the file (after cleaning the cache) while the first
 # instance is having issues. We don't let enough time to the monitoring process
@@ -175,7 +175,7 @@ fusermount -u /mnt/fuse
 
 rm -f "${CG_STORAGE_MANAGER_SYMLINK_CONF}"
 ln -s "${CG_STORAGE_MANAGER_SECOND_DOWN_CONF}" "${CG_STORAGE_MANAGER_SYMLINK_CONF}"
-kill -HUP `cat /tmp/CloudGatewayStorageManager.pid`
+kill -HUP `cat /run/cloudgateway/CloudGatewayStorageManager.pid`
 
 # Ok, now we try to access the file (after cleaning the cache) while the second
 # instance is having issues. We don't let enough time to the monitoring process
@@ -207,7 +207,7 @@ fusermount -u /mnt/fuse
 
 rm -f "${CG_STORAGE_MANAGER_SYMLINK_CONF}"
 ln -s "${CG_STORAGE_MANAGER_ALL_DOWN_CONF}" "${CG_STORAGE_MANAGER_SYMLINK_CONF}"
-kill -HUP `cat /tmp/CloudGatewayStorageManager.pid`
+kill -HUP `cat /run/cloudgateway/CloudGatewayStorageManager.pid`
 
 # Ok, now we try to access the file (after cleaning the cache) while all instances
 # are down. Obviously this should fail. We don't let enough time to the monitoring process
@@ -234,7 +234,7 @@ fusermount -u /mnt/fuse
 
 rm -f "${CG_STORAGE_MANAGER_SYMLINK_CONF}"
 ln -s "${CG_STORAGE_MANAGER_FIRST_DOWN_CONF}" "${CG_STORAGE_MANAGER_SYMLINK_CONF}"
-kill -HUP `cat /tmp/CloudGatewayStorageManager.pid`
+kill -HUP `cat /run/cloudgateway/CloudGatewayStorageManager.pid`
 
 # Ok, now we try to access the file (after cleaning the cache) while the first
 # instance is having issues. This time we wait while the monitoring process
@@ -265,7 +265,7 @@ fusermount -u /mnt/fuse
 
 rm -f "${CG_STORAGE_MANAGER_SYMLINK_CONF}"
 ln -s "${CG_STORAGE_MANAGER_SECOND_DOWN_CONF}" "${CG_STORAGE_MANAGER_SYMLINK_CONF}"
-kill -HUP `cat /tmp/CloudGatewayStorageManager.pid`
+kill -HUP `cat /run/cloudgateway/CloudGatewayStorageManager.pid`
 
 # Ok, now we try to access the file (after cleaning the cache) while the second
 # instance is having issues. This time we wait while the monitoring process
@@ -296,7 +296,7 @@ fusermount -u /mnt/fuse
 
 rm -f "${CG_STORAGE_MANAGER_SYMLINK_CONF}"
 ln -s "${CG_STORAGE_MANAGER_ALL_DOWN_CONF}" "${CG_STORAGE_MANAGER_SYMLINK_CONF}"
-kill -HUP `cat /tmp/CloudGatewayStorageManager.pid`
+kill -HUP `cat /run/cloudgateway/CloudGatewayStorageManager.pid`
 
 # Ok, now we try to access the file (after cleaning the cache) while all instances
 # are down. Obviously this should fail. This time we wait while the monitoring process
@@ -327,7 +327,7 @@ fusermount -u /mnt/fuse
 
 rm -f "${CG_STORAGE_MANAGER_SYMLINK_CONF}"
 ln -s "${CG_STORAGE_MANAGER_VALID_CONF}" "${CG_STORAGE_MANAGER_SYMLINK_CONF}"
-kill -HUP `cat /tmp/CloudGatewayStorageManager.pid`
+kill -HUP `cat /run/cloudgateway/CloudGatewayStorageManager.pid`
 
 # We need to launch a working Storage Manager, otherwise the
 # test file will remain
@@ -338,7 +338,7 @@ if [ $? -ne 0 ]; then
     fail "Unmount failure.";
 fi
 
-kill -USR1 `cat /tmp/CloudGatewayStorageManager.pid`
+kill -USR1 `cat /run/cloudgateway/CloudGatewayStorageManager.pid`
 
 if [ $? -ne 0 ]; then
     fail "cgStorageManager stop failure.";

--- a/src/tools/cg_stats.c
+++ b/src/tools/cg_stats.c
@@ -36,8 +36,8 @@
 #include "common.h"
 #include "tools_provider_stats_common.h"
 
-#define CG_STATS_FILE_DEFAULT "/tmp/cgStatsFile.json"
-#define CG_STATS_LOG_FILE_DEFAULT "/tmp/CloudGatewayStats.err"
+#define CG_STATS_FILE_DEFAULT "/run/cloudgateway/cgStatsFile.json"
+#define CG_STATS_LOG_FILE_DEFAULT "/run/cloudgateway/CloudGatewayStats.err"
 
 #define CG_STATS_KEEP_DEFAULT (60)
 #define CG_STATS_DELAY_DEFAULT (1)


### PR DESCRIPTION
Use /run and /var/log instead of /usr/local/run and /tmp.